### PR TITLE
Fix bug where apps list is empty

### DIFF
--- a/app/src/main/java/com/buddybuild/ui/OverviewActivity.java
+++ b/app/src/main/java/com/buddybuild/ui/OverviewActivity.java
@@ -107,6 +107,7 @@ public class OverviewActivity extends AppCompatActivity implements AppsFragment.
                             if (!apps.isEmpty()) {
                                 updateBuildsFragment(apps.get(0).getId());
                             } else {
+                                // TODO instead consider showing empty "create an app first" screen
                                 updateBuildsFragment(null);
                             }
                             updateToolbar();
@@ -142,11 +143,15 @@ public class OverviewActivity extends AppCompatActivity implements AppsFragment.
                     toolbar.setSubtitle(app.getPlatform().prettyString());
                 }
             }
-        } else {
-            // if none selected, just display the top one
+        } else if (apps.size() > 0) {
+            // if none selected, just display the first one
             App app = apps.get(0);
             toolbar.setTitle(app.getName());
             toolbar.setSubtitle(app.getPlatform().prettyString());
+        } else {
+            // if user has no apps, clear everything
+            toolbar.setTitle("");
+            toolbar.setSubtitle("");
         }
     }
 }


### PR DESCRIPTION
It's possible user logs in and has no apps. In that case the updateToolbar would crash. So the thing to do instead is just clear out toolbar title/subtitle.

```
Caused by: java.lang.IndexOutOfBoundsException: 
  at java.util.ArrayList.get (ArrayList.java:411)
  at com.buddybuild.ui.OverviewActivity.updateToolbar (OverviewActivity.java:147)
  at com.buddybuild.ui.OverviewActivity.lambda$onCreate$3$OverviewActivity (OverviewActivity.java:112)
  at com.buddybuild.ui.OverviewActivity$$Lambda$3.accept (Unknown Source)
  at io.reactivex.internal.observers.ConsumerSingleObserver.onSuccess (ConsumerSingleObserver.java:61)
```