### PR TITLE
Play with toothpick

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,10 +166,23 @@ dependencies {
     testCompile('org.threeten:threetenbp:1.3.2') {
         exclude group: 'com.jakewharton.threetenabp', module: 'threetenabp'
     }
+
     testImplementation 'junit:junit:' + rootProject.ext.junitVersion
+
     testImplementation "org.assertj:assertj-core:$rootProject.ext.assertJVersion"
+
+    testImplementation "org.mockito:mockito-core:2.13.0"
+
     testImplementation "org.robolectric:robolectric:3.4.2"
     testImplementation "org.robolectric:shadows-support-v4:3.4-rc2"
+
+    // LEFT OFF HERE: we have to have these dependencies "in-app" for test to work. Does this cause Dagger to stop
+    // working in-app?
+    implementation 'com.github.stephanenicolas.toothpick:toothpick-runtime:1.1.1'
+    implementation 'com.github.stephanenicolas.toothpick:smoothie:1.1.1'
+    annotationProcessor 'com.github.stephanenicolas.toothpick:toothpick-compiler:1.1.1'
+    testImplementation 'com.github.stephanenicolas.toothpick:toothpick-testing:1.1.1'
+    testAnnotationProcessor 'com.github.stephanenicolas.toothpick:toothpick-compiler:1.1.1'
 
     // ---------------
     // INSTRUMENTATION TEST DEPENDENCIES

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,11 @@ android {
         warningsAsErrors true
         lintConfig file('../config/lint.xml')
     }
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 check {
@@ -154,6 +159,17 @@ dependencies {
     // https://github.com/ACRA/acra
     // Apache 2.0
     implementation 'com.faendir:acra:4.10.0'
+
+    // ---------------
+    // LOCAL UNIT TEST DEPENDENCIES
+    // ---------------
+    testCompile('org.threeten:threetenbp:1.3.2') {
+        exclude group: 'com.jakewharton.threetenabp', module: 'threetenabp'
+    }
+    testImplementation 'junit:junit:' + rootProject.ext.junitVersion
+    testImplementation "org.assertj:assertj-core:$rootProject.ext.assertJVersion"
+    testImplementation "org.robolectric:robolectric:3.4.2"
+    testImplementation "org.robolectric:shadows-support-v4:3.4-rc2"
 
     // ---------------
     // INSTRUMENTATION TEST DEPENDENCIES

--- a/app/src/main/java/com/buddybuild/BuddyBuildApplication.java
+++ b/app/src/main/java/com/buddybuild/BuddyBuildApplication.java
@@ -19,7 +19,7 @@ public class BuddyBuildApplication extends Application {
         super.onCreate();
         component = createComponent();
 
-        AndroidThreeTen.init(this);
+        setupThreeTenLib();
 
         setupLogging();
 
@@ -35,6 +35,13 @@ public class BuddyBuildApplication extends Application {
                 .mainModule(new MainModule(this))
                 .build();
     }
+    
+    /**
+     * Subclasses can override to enable/disable/change setup of Three Ten ABP library
+     */
+    protected void setupThreeTenLib() {
+        AndroidThreeTen.init(this);
+    }
 
     private void setupLogging() {
         // we want to log in Debug builds
@@ -44,5 +51,4 @@ public class BuddyBuildApplication extends Application {
             // TODO crash reporting tree
         }
     }
-
 }

--- a/app/src/test/java/com/buddybuild/NoDependencyInjectionApplication.java
+++ b/app/src/test/java/com/buddybuild/NoDependencyInjectionApplication.java
@@ -1,0 +1,72 @@
+package com.buddybuild;
+
+import com.buddybuild.di.MainComponent;
+import com.buddybuild.ui.AppsFragment;
+import com.buddybuild.ui.BuildDetailPagerFragment;
+import com.buddybuild.ui.BuildDetailsFragment;
+import com.buddybuild.ui.BuildsFragment;
+import com.buddybuild.ui.LogFragment;
+import com.buddybuild.ui.LoginFragment;
+import com.buddybuild.ui.OverviewActivity;
+import com.buddybuild.ui.SettingsFragment;
+
+/**
+ * Extension of {@link BuddyBuildApplication} that does NOT setup three-ten-abp and does NOT setup Dagger D.I.
+ */
+public class NoDependencyInjectionApplication extends BuddyBuildApplication {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+
+    @Override
+    protected MainComponent createComponent() {
+        return new MainComponent() {
+
+            @Override
+            public void inject(AppsFragment appsFragment) {
+                // no-op
+            }
+
+            @Override
+            public void inject(LoginFragment loginFragment) {
+                // no-op
+            }
+
+            @Override
+            public void inject(OverviewActivity overviewActivity) {
+                // no-op
+            }
+
+            @Override
+            public void inject(BuildsFragment buildsFragment) {
+                // no-op
+            }
+
+            @Override
+            public void inject(LogFragment logFragment) {
+                // no-op
+            }
+
+            @Override
+            public void inject(BuildDetailPagerFragment buildDetailPagerFragment) {
+                // no-op
+            }
+
+            @Override
+            public void inject(BuildDetailsFragment buildDetailsFragment) {
+                // no-op
+            }
+
+            @Override
+            public void inject(SettingsFragment settingsFragment) {
+                // no-op
+            }
+        };
+    }
+
+    @Override
+    protected void setupThreeTenLib() {
+        // do nothing, do not call super
+    }
+}

--- a/app/src/test/java/com/buddybuild/ui/LoginFragmentTest2.java
+++ b/app/src/test/java/com/buddybuild/ui/LoginFragmentTest2.java
@@ -1,12 +1,23 @@
 package com.buddybuild.ui;
 
+import com.buddybuild.Coordinator;
+import com.buddybuild.DemoManager;
 import com.buddybuild.NoDependencyInjectionApplication;
 
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.support.v4.SupportFragmentTestUtil;
+
+import javax.inject.Inject;
+
+import toothpick.testing.ToothPickRule;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -17,13 +28,29 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 @Config(application = NoDependencyInjectionApplication.class, packageName = "com.buddybuild")
 public class LoginFragmentTest2 {
 
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+    @Rule
+    public ToothPickRule toothPickRule = new ToothPickRule(this, "LOGIN FRAGMENT SCOPE");
+
+    @Mock
+    Coordinator coordinator;
+    @Mock
+    DemoManager demoManager;
+    @Inject
+    LoginFragment loginFragment;
+
+    @Before
+    public void setUp() {
+        toothPickRule.inject(this);
+    }
+
     /**
      * A helper test to ensure that Robolectric is working right
      */
     @Test
     public void robolectricCanStartFragment() throws Exception {
         // arrange
-        LoginFragment loginFragment = LoginFragment.newInstance();
 
         // act
         SupportFragmentTestUtil.startFragment(loginFragment);

--- a/app/src/test/java/com/buddybuild/ui/LoginFragmentTest2.java
+++ b/app/src/test/java/com/buddybuild/ui/LoginFragmentTest2.java
@@ -1,0 +1,34 @@
+package com.buddybuild.ui;
+
+import com.buddybuild.NoDependencyInjectionApplication;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.support.v4.SupportFragmentTestUtil;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+/**
+ * Unit tests for {@link com.buddybuild.ui.LoginFragment}
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(application = NoDependencyInjectionApplication.class, packageName = "com.buddybuild")
+public class LoginFragmentTest2 {
+
+    /**
+     * A helper test to ensure that Robolectric is working right
+     */
+    @Test
+    public void robolectricCanStartFragment() throws Exception {
+        // arrange
+        LoginFragment loginFragment = LoginFragment.newInstance();
+
+        // act
+        SupportFragmentTestUtil.startFragment(loginFragment);
+
+        // assert
+        assertThat(loginFragment.isResumed()).isTrue();
+    }
+}


### PR DESCRIPTION
The goal is to try to use Toothpick in UI-based unit tests *only*. We don't want to switch away from Dagger entirely. Dagger doesn't do field injection in tests very well (we have to create a new module for each test). Because of Toothpick's unique annotations we can rely on the existing `@Inject` statements in app code and have Toothpick provide these injected fields in unit tests.

Everything works well. Toothpick injects fields for unit tests! The problem is that we have to include Toothpick dependencies in app code as well as test code (see changes to build.gradle). This doesn't interfere with Dagger, but I'm not so sure that I like it.